### PR TITLE
Add dockerfile and tweak makefile a bit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM node:lts
+
+RUN npm install -g @vue/cli

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,6 @@ bash:
 clean:
 	rm -rf subgraph.yaml src/constants.ts generated/ build/
 
-setup-thegraph:
-	yarn graph auth --product hosted-service $(auth_token)
-
 generate-config:
 	YARN_SILENT=1 yarn mustache config/$(network).subgraph.json subgraph.mustache > subgraph.yaml && \
 	YARN_SILENT=1 yarn mustache config/$(network).constants.json src/constants.mustache > src/constants.ts

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,31 @@
-.PHONY: config
-config:
+build-docker:
+	docker build -t moonwell-subgraph .
+
+bash:
+	docker run --rm -it \
+		-v $$(pwd):$$(pwd) \
+		--workdir $$(pwd) \
+		moonwell-subgraph \
+		bash
+
+clean:
+	rm -rf subgraph.yaml src/constants.ts generated/ build/
+
+setup-thegraph:
+	yarn graph auth --product hosted-service $(auth_token)
+
+generate-config:
 	YARN_SILENT=1 yarn mustache config/$(network).subgraph.json subgraph.mustache > subgraph.yaml && \
 	YARN_SILENT=1 yarn mustache config/$(network).constants.json src/constants.mustache > src/constants.ts
 
-.PHONY: codegen
 codegen:
-	$(MAKE) config && yarn graph codegen
+	yarn graph codegen
 
-.PHONY: build
 build:
-	$(MAKE) config && yarn graph build
+	yarn graph build
 
-.PHONY: deploy
 deploy:
-	yarn graph deploy 0xbe1/moonwell-$(network) --node https://api.thegraph.com/deploy/
+	yarn graph deploy moonwell-fi/moonwell-$(network) --access-token $(access_token) --node https://api.thegraph.com/deploy/
+
+all:
+	$(MAKE) clean generate-config codegen build deploy


### PR DESCRIPTION
This PR adds in a dockerfile and tweaks the makefile to:
- Add docker support (so spinning up the dev environment is as easy as `make build-docker bash`
- Adds `make clean` to reset the dev env
- Adds `all` to do everything in one command (`make all network=moonriver access_token=abc123` to generate + deploy)
- Removes `.PHONY` declarations - it's only an issue because there was a build step named `config` and a folder named `config` - I changed the `config` build step to `make generate-config`
- Passes in `access_token` as part of deploys