### PR TITLE
fix: missing reward

### DIFF
--- a/src/markets.ts
+++ b/src/markets.ts
@@ -109,8 +109,8 @@ export function createMarket(marketID: string): Market | null {
 
   market.accrualBlockTimestamp = 0
   market.blockTimestamp = 0
-  market.mintPaused = false;
-  market.borrowPaused = false;
+  market.mintPaused = false
+  market.borrowPaused = false
 
   // find price feed of the market
   let comptroller = Comptroller.load('1')!
@@ -179,7 +179,7 @@ export function updateMarket(
       .truncate(market.underlyingDecimals)
     market.borrowIndex = event.params.borrowIndex
 
-    let nativeMarket = Market.load(mNativeAddr)
+    let nativeMarket = Market.load(Address.fromString(mNativeAddr).toHexString())
     if (nativeMarket) {
       let nativeTokenPriceUSD = nativeMarket.underlyingPriceUSD
       if (nativeTokenPriceUSD.gt(zeroBD)) {


### PR DESCRIPTION
mNativeAddr is set to be `0x091608f4e4a15335145be0A279483C0f8E4c7955` (see moonbeam.constants.json) however we store the market as id = `0x091608f4e4a15335145be0a279483c0f8e4c7955` - they are different!

as a result, `nativeMarket` is null.

to fix the issue, I use `Address.fromString(s).toHexString()` to process `mNativeAddr` s.t. it conforms with our standard. This fixes the issue:

https://api.thegraph.com/subgraphs/id/QmSJMCS3j1LyB7zpmz2AXxDwd3vPUcBcnWZiz71RF9EgSn/graphql?query=%7B%0A++markets+%7B%0A++++id%0A++++supplyRewardNative%0A++++borrowRewardNative%0A++%7D%0A%7D