### PR TITLE
More reliable daily market snapshots

### DIFF
--- a/src/ctoken.ts
+++ b/src/ctoken.ts
@@ -507,7 +507,8 @@ export function handleAccrueInterest(event: AccrueInterest): void {
     event.block.number.toI32(),
     event,
   )
-  snapshotMarket(event.address, event.block.timestamp.toI32())
+  // Moved this into the price handler so snapshots can get taken more frequently
+  // snapshotMarket(event.address, event.block.timestamp.toI32())
 }
 
 export function handleNewReserveFactor(event: NewReserveFactor): void {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -118,8 +118,10 @@ export function getOrCreateMarketDailySnapshot(
   blockTimestamp: i32,
 ): MarketDailySnapshot {
   let snapshotID = marketID.concat('-').concat(getEpochDays(blockTimestamp).toString())
+  log.info('[getorCreateMarketDailySnapshot] snapshotID: {}', [snapshotID])
   let snapshot = MarketDailySnapshot.load(snapshotID)
   if (!snapshot) {
+    log.warning('[getorCreateMarketDailySnapshot] snapshot not found, creating new snapshot {}', [snapshotID])
     snapshot = new MarketDailySnapshot(snapshotID)
     snapshot.market = marketID
     snapshot.totalBorrows = zeroBD

--- a/src/price.ts
+++ b/src/price.ts
@@ -6,6 +6,7 @@ import { PriceOracle } from '../generated/templates/CToken/PriceOracle'
 import { addrEq, exponentToBigDecimal, zeroBD } from './helpers'
 import config from '../config/config'
 import { Feed } from '../generated/templates'
+import { snapshotMarket } from './markets'
 
 // Special handler that hardcodes _feed for certain market at a certain block.
 // This is necessary because Chainlink could change mtoken feed address through private transaction
@@ -74,6 +75,7 @@ export function handleAnswerUpdated(event: AnswerUpdated): void {
       }
     }
     market.save()
+    snapshotMarket(Address.fromString(market.id), event.block.timestamp.toI32())
   }
 }
 


### PR DESCRIPTION
I think this will give us more reliable daily market snapshots. By firing on `answerUpdated` event from Chainlink, we should get at least 1 event handler trigger every 24 hours, so we should now have daily market snapshots for every market for every day, even the ones that are deprecated and don't have borrowers repaying to trigger `handleAccrueInterest`.