### PR TITLE
Review moonwell-subgraph-query file

### DIFF
--- a/moonwell-subgraph-query
+++ b/moonwell-subgraph-query
@@ -1,0 +1,14 @@
+Moonwell: Incentive data for GLMR
+Querying for the current state of the market, not historical.
+
+{
+  markets(first: 5, where: {symbol: "mGLMR"}) {
+    id
+    name
+    symbol
+    supplyRewardSpeedNative
+    blockTimestamp
+    underlyingSymbol
+    underlyingPriceUSD
+  }
+}


### PR DESCRIPTION
Hey, 

Would appreciate your review and corrections to the subgraph query for the historical incentives data for native token GLMR. It's outputting the current state of the market, not historical incentives for GLMR.